### PR TITLE
rearranging grid layout, gridfooter should be placed within .card-foo…

### DIFF
--- a/Tk.BlazorGrid/TkGrid/Common/GridBase.cs
+++ b/Tk.BlazorGrid/TkGrid/Common/GridBase.cs
@@ -15,6 +15,8 @@ namespace TkGrid
 
 		public bool EnableSearch { get; set; } = false;
 
+		public bool EnableAdd { get; set; } = false;
+
 		public int MaxPages { get; set; } = 10;
 
 		//frontend required stuff

--- a/Tk.BlazorGrid/TkGrid/GridFooter.razor
+++ b/Tk.BlazorGrid/TkGrid/GridFooter.razor
@@ -1,5 +1,4 @@
-﻿
-@if (gridBase.CurrentPage <= gridBase.MaxPage)
+﻿@if (gridBase.CurrentPage <= gridBase.MaxPage)
 {
     <nav aria-label="Page navigation">
         <ul class="pagination">
@@ -27,11 +26,23 @@
             }
         </ul>
     </nav>
+    <div class="ml-auto">
+        @gridBase.TotalCount result(s) found
+    </div>
+    <EditForm Model="@gridBase" class="ml-auto">
+        <div class="input-group">
+            <div class="input-group-prepend">
+                <label class="input-group-text" for="pageValue">Items per Page</label>
+            </div>
+            <select id="pageValue" @onchange="DoPageSizeChange" class="custom-select">
+                <option selected value="5">5</option>
+                <option value="10">10</option>
+                <option value="20">20</option>
+                <option value="100">100</option>
+            </select>
+        </div>
+    </EditForm>
 }
-
-<div class="small">
-    @gridBase.TotalCount result(s) found
-</div>
 
 @code {
     [Parameter]
@@ -40,8 +51,17 @@
     [Parameter]
     public EventCallback<GridBase> OnPageClick { get; set; }
 
+    [Parameter]
+    public EventCallback<GridBase> OnPageSizeChange { get; set; }
+
+    protected async Task DoPageSizeChange(ChangeEventArgs e)
+    {
+        gridBase.PageSize = Convert.ToInt32(e.Value.ToString());
+        await OnPageSizeChange.InvokeAsync(gridBase);
+    }
+
     protected async Task GetPagedData(int clickedPage = 1)
-    {        
+    {
         gridBase.CurrentPage = clickedPage;
         await OnPageClick.InvokeAsync(gridBase);
     }

--- a/Tk.BlazorGrid/TkGrid/GridHeader.razor
+++ b/Tk.BlazorGrid/TkGrid/GridHeader.razor
@@ -1,31 +1,27 @@
 ﻿
-<EditForm Model="@gridBase">
-    <div class="form-row mb-3">
-        <div class="col-1">
-            <select id="pageValue" @onchange="DoPageSizeChange" class="form-control">
-                <option selected value="5">5</option>
-                <option value="10">10</option>
-                <option value="20">20</option>
-                <option value="100">100</option>
-            </select>
-        </div>
-        <div class="col-11">
-            @if (gridBase.EnableSearch)
-            {
-                <div class="input-group">
-                    <div class="custom-file">
-                        <InputText id="searchText" @bind-Value="gridBase.Search" placeholder="Search..." class="form-control" />                        
-                    </div>
-                    <div class="input-group-append">
-                        <button type="button" class="btn" @onclick="DoPageSearch"><i class="fas fa-search"></i></button>
-                    </div>
-                    <div class="input-group-append">
-                        <button type="button" class="btn" @onclick="DoReset"><i class="fas fa-sync"></i></button>
-                    </div>
+<EditForm Model="@gridBase" class="form-inline w-100">
+    @if (gridBase.EnableSearch)
+    {
+        <div class="w-75">
+            <div class="input-group">
+                <InputText id="searchText" @bind-Value="gridBase.Search" placeholder="Search..." class="form-control" />
+                <div class="input-group-append">
+                    <button type="button" class="btn btn-outline-dark" @onclick="DoPageSearch"><i class="fas fa-search"></i></button>
                 </div>
-            }
+                <div class="input-group-append">
+                    <button type="button" class="btn btn-outline-dark" @onclick="DoReset"><i class="fas fa-sync"></i></button>
+                </div>
+            </div>
         </div>
-    </div>
+    }
+    @if (gridBase.EnableAdd)
+    {
+        <div class="ml-auto">
+            <button type="button" class="btn icon btn-primary" @onclick="DoCreate">
+                <i class="fas fa-plus"></i>
+            </button>
+        </div>
+    }
 </EditForm>
 
 @code {
@@ -33,21 +29,19 @@
     public GridBase gridBase { get; set; }
 
     [Parameter]
-    public EventCallback<GridBase> OnPageSizeChange { get; set; }
-
-    [Parameter]
     public EventCallback<GridBase> OnPageSearch { get; set; }
 
-
-    protected async Task DoPageSizeChange(ChangeEventArgs e)
-    {
-        gridBase.PageSize = Convert.ToInt32(e.Value.ToString());
-        await OnPageSizeChange.InvokeAsync(gridBase);
-    }
+    [Parameter]
+    public EventCallback<GridBase> OnCreate { get; set; }
 
     protected async Task DoPageSearch()
     {
         await OnPageSearch.InvokeAsync(gridBase);
+    }
+
+    protected async Task DoCreate()
+    {
+        await OnCreate.InvokeAsync(gridBase);
     }
 
     protected async Task DoReset()

--- a/Tk.BlazorGrid/TkGrid/TkGrid.csproj
+++ b/Tk.BlazorGrid/TkGrid/TkGrid.csproj
@@ -4,7 +4,9 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0.3</Version>
+    <Version>1.0.0.10</Version>
+    <PackageReleaseNotes>rearrange grid layout
+add onCreate function</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I updated the grid layout.  It is assumed (by me), that the grid-header will go inside of .card-header, and grid-footer will go inside of .card-footer. I also added  OnCreate and EnableAdd to allow for CRUD table functionality, if necessary.